### PR TITLE
support AWS environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ mbtiles-extractor --input=some.mbtiles --outputType=local --localOutDir=Data --t
 
 `--acl=public-read` The access control level of the tile.
 
+An optional `AWS_S3_ENDPOINT` environment variable may be provided, which is mainly used for S3 compatiable services. eg. `export AWS_S3_ENDPOINT=https://sgp1.digitaloceanspaces.com` if using Digital Ocean Spaces.
+
 #### Local storage options
 
 `--localOutDir` **Required** The name of a folder to place the tiles in.

--- a/src/main.js
+++ b/src/main.js
@@ -223,6 +223,15 @@ export async function cli () {
                 agent: defaultAgent
             }
         }
+        if (process.env.AWS_ACCESS_KEY_ID) {
+            awsOptions.accessKeyId = process.env.AWS_ACCESS_KEY_ID
+        }
+        if (process.env.AWS_SECRET_ACCESS_KEY) {
+            awsOptions.secretAccessKey = process.env.AWS_SECRET_ACCESS_KEY
+        }
+        if (process.env.AWS_S3_ENDPOINT) {
+            awsOptions.endpoint = new AWS.Endpoint(process.env.AWS_S3_ENDPOINT)
+        }
         if (options.awsProfile) {
             const profile = await adoptProfile()
             Object.assign(awsOptions, profile);

--- a/src/main.js
+++ b/src/main.js
@@ -223,12 +223,6 @@ export async function cli () {
                 agent: defaultAgent
             }
         }
-        if (process.env.AWS_ACCESS_KEY_ID) {
-            awsOptions.accessKeyId = process.env.AWS_ACCESS_KEY_ID
-        }
-        if (process.env.AWS_SECRET_ACCESS_KEY) {
-            awsOptions.secretAccessKey = process.env.AWS_SECRET_ACCESS_KEY
-        }
         if (process.env.AWS_S3_ENDPOINT) {
             awsOptions.endpoint = new AWS.Endpoint(process.env.AWS_S3_ENDPOINT)
         }


### PR DESCRIPTION
up to you if you want to accept this, and I'm not even sure if it's the correct approach, but I found I needed to do this in order to do authentication via environment variables.

For the endpoint, I don't think it's possible to set this via an AWS profile so as far as I can tell this is the only way when trying to use an S3-compatible object storage not from Amazon.